### PR TITLE
upgraded scala version + packages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,15 @@ name := "ticker"
 
 version := "1.0"
 
-scalaVersion := "2.12.5"
+scalaVersion := "2.12.15"
 
 cancelable in Global := true
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.12" % "test"
 
-libraryDependencies += "com.github.scopt" %% "scopt" % "3.5.0"
-libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5"
-libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2"
+libraryDependencies += "com.github.scopt" %% "scopt" % "4.0.1"
+libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
+libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5"
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3"
 
 scalacOptions += "-feature"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.2
+sbt.version=1.6.2


### PR DESCRIPTION
This upgrades scala and some dependencies to be able to execute Ticker again (at least on Mac OS)

```sh
sbt "run --program src/test/resources/program.lars"
[info] welcome to sbt 1.6.2 (Homebrew Java 18.0.1.1)
[info] loading settings for project ticker-build from assembly.sbt,plugins.sbt ...
[info] loading project definition from ~/ticker/project
[info] loading settings for project ticker from build.sbt ...
[info] set current project to ticker (in build file:/~/uni/ticker/)
[warn] there's a key that's not used by any other settings/tasks:
[warn]
[warn] * ticker / assembly / excludeFilter
[warn]   +- ~/uni/ticker/build.sbt:51
[warn]
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
[info] running Program --program src/test/resources/program.lars
1s (t=1): Set()
rec(1)
rec(1)
rec(1)
rec(2)
rec(2)
13s (t=13): Set(moreThanTwo)
20s (t=20): Set()
```

Note tests are ATM not compiling, this requires additional work